### PR TITLE
Add presets for flashing by listener or by device

### DIFF
--- a/index.js
+++ b/index.js
@@ -410,6 +410,7 @@ instance.prototype.initModule = function () {
 			}
 
 			self.actions();
+			self.initPresets();
 			self.initFeedbacks();
 			self.checkFeedbacks('listener_clients');
 		});
@@ -486,6 +487,46 @@ instance.prototype.initPresets = function () {
 					}
 				}
 			]
+		});
+	}
+
+	for (let i = 0; i < self.devices.length; i++) {
+		presets.push({
+			category: 'Flash a device',
+			label: 'device '+self.devices[i].name,
+			bank: {
+				style: 'text',
+				text: 'Flash '+self.devices[i].name,
+				size: '16',
+				color: '16777215',
+				bgcolor: self.rgb(0,0,0)
+			},
+			actions: [{
+				action: 'flash_device',
+				options: {
+					'device': self.devices[i].id,
+				}
+			}]
+		});
+	}
+
+	for (let i = 0; i < self.listener_clients.length; i++) {
+		presets.push({
+			category: 'Flash a listener',
+			label: 'listener '+self.listener_clients[i].id,
+			bank: {
+				style: 'text',
+				text: 'Flash '+self.listener_clients[i].id,
+				size: '12',
+				color: '16777215',
+				bgcolor: self.rgb(0,0,0)
+			},
+			actions: [{
+				action: 'flash_listener_client',
+				options: {
+					'listener_client': self.listener_clients[i].id,
+				}
+			}]
 		});
 	}
 


### PR DESCRIPTION
As written in https://github.com/josephdadams/TallyArbiter/issues/315#issuecomment-1039710140
```
I think you can't belive me...
I was working on this, and I was opening a PR when I saw the notification...
🤦‍♂️😂

My implementation supports presets for flashing listeners (by listener id or by device).
I'll open a PR in the next minutes.
```