### PR TITLE
Flash all listeners to specific device not working

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -16,7 +16,7 @@ module.exports = {
 			],
 			callback: async (event) => {
 				for (let i = 0; i < self.listener_clients.length; i++) {
-					if (self.listener_clients[i].deviceId === options.device) {
+					if (self.listener_clients[i].deviceId === event.options.device) {
 						self.sendCommand('flash', self.listener_clients[i].id);
 					}
 				}


### PR DESCRIPTION
Flashing the screens of all connections to a device is not working for me. I think this change is needed to make the functions work as expected.